### PR TITLE
Replaces cloud.goog-based service name with appspot.com-based one.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,7 +18,7 @@ info:
   description: "Get the name of an airport from its three-letter IATA code."
   version: "1.0.0"
 # This field will be replaced by the deploy_api.sh script.
-host: "airports-api.endpoints.YOUR-PROJECT-ID.cloud.goog"
+host: "YOUR-PROJECT-ID.appspot.com"
 schemes:
   - "https"
 paths:

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -27,7 +27,7 @@ main() {
   gcloud app create --region="$REGION" || true
   # Prepare the necessary variables for substitution in our app configuration
   # template, and create a temporary file to hold the templatized version.
-  local service_name="${API_NAME}.endpoints.${project_id}.cloud.goog"
+  local service_name="${project_id}.appspot.com"
   local config_id=$(get_latest_config_id "$service_name")
   export TEMP_FILE="${APP}_deploy.yaml"
   < "$APP" \

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -16,10 +16,6 @@
 # Make Bash a little less error-prone.
 set -euo pipefail
 
-# This is for the included Airports sample. But you could change this to work
-# with other APIs.
-export API_NAME="airports-api"
-
 get_latest_config_id() {
   # Given a service name, this returns the most recent deployment of that
   # API.


### PR DESCRIPTION
The application is not actually accessible at the cloud.goog address, making it
inappropriate to use in the service configuration.