### PR TITLE
Replace gcloud service-management with gcloud endpoints.

### DIFF
--- a/scripts/deploy_api.sh
+++ b/scripts/deploy_api.sh
@@ -30,8 +30,8 @@ main() {
   # substitution before we can deploy it. Sed does this nicely.
   < "$API_FILE" sed -E "s/YOUR-PROJECT-ID/${project_id}/g" > "$TEMP_FILE"
   echo "Deploying $API_FILE..."
-  echo "gcloud service-management deploy $API_FILE"
-  gcloud service-management deploy "$TEMP_FILE"
+  echo "gcloud endpoints services deploy $API_FILE"
+  gcloud endpoints services deploy "$TEMP_FILE"
 }
 
 cleanup() {

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -20,7 +20,7 @@ get_latest_config_id() {
   # Given a service name, this returns the most recent deployment of that
   # API.
   service_name="$1"
-  gcloud service-management configs list \
+  gcloud endpoints configs list \
     --service="$service_name" \
     --sort-by="~config_id" --limit=1 --format="value(CONFIG_ID)" \
     | tr -d '[:space:]'


### PR DESCRIPTION
`gcloud service-management` is deprecated and replaced with `gcloud endpoints`.