### PR TITLE
Fixing app deployment script

### DIFF
--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -30,7 +30,7 @@ main() {
   # Prepare the necessary variables for substitution in our app configuration
   # template, and create a temporary file to hold the templatized version.
   local service_name="${project_id}.appspot.com"
-  export TEMP_FILE="${APP}_deploy.yaml"
+  export TEMP_FILE="../app/app.yaml"
   < "$APP" \
     sed -E "s/SERVICE_NAME/${service_name}/g" \
     > "$TEMP_FILE"


### PR DESCRIPTION
We need to make sure app.yaml that is generated from app yaml template is called app.yaml. Otherwise deployment with gcloud beta app deploy will fail.